### PR TITLE
To order consent updates by time you need to check the events timestamp

### DIFF
--- a/docs/consent/index.md
+++ b/docs/consent/index.md
@@ -374,4 +374,11 @@ This log will show the last 7 days of events for alle consents given to you.
 
 You will need to use an access token with scope="consent.events" and audience set to "https://api-preprod.norskgjeld.no/feed/v1/consent" (for preprod) or "https://api.norskgjeld.no/feed/v1/consent" (for production) when calling this API.
 
+NOTE: The sequence numbers you receive will not necessarily correlate to the time a change happened.\
+You must check the timestamps inside the events if you need to order them by when they happened.\
+Sequence number 3 might contain an event that occurred _after_ sequence number 4.
+
+NOTE: The sequence numbers are not guaranteed to be contiguous. You might receive a response containing {seq. nr: 7, seq. nr: 8, seq. nr: 13}.\
+The sequence numbers 9-12 are not missing.
+
 The API is defined [here](Open API#operations-tag-Consents_Feed_API).


### PR DESCRIPTION
When using the new API to poll for updates on your registered consents there is no guaranteed ordering by time.

This PR explains this to consumers of this API.